### PR TITLE
Switch to GitHub Actions-based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Lint
+      run: |
+        php --version
+        find . -name "*.php" -print0 | xargs -0 -n1 php -l

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: php
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - nightly
-script: find . -name "*.php" -exec php -l {} \; | grep -v '^No syntax errors detected'; test $? -eq 1


### PR DESCRIPTION
GitHub Actions provides a nicer alternate to Travis for running
continuous integration jobs.