### PR TITLE
Add JSON output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@
 This is an [Arcanist][] extension that displays file ownership information.
 It is implemented as an `arc owners` command:
 
-    owners [path ...]
+    owners [options] [path ...]
         Supports: git, hg
         Display ownership information for a list of files.
 
         Without paths, the files changed in your local working copy will
         be used.
+
+        --output format
+            With 'json', show owners in machine-readable JSON format.
 
 ```
 $ arc owners README.md

--- a/src/ArcanistOwnersWorkflow.php
+++ b/src/ArcanistOwnersWorkflow.php
@@ -26,7 +26,7 @@ final class ArcanistOwnersWorkflow extends ArcanistWorkflow {
 
     public function getCommandSynopses() {
         return phutil_console_format(<<<EOTEXT
-      **owners** [__path__ ...]
+      **owners** [__options__] [__path__ ...]
 EOTEXT
       );
     }
@@ -56,6 +56,15 @@ EOTEXT
 
   public function getArguments() {
     return array(
+      'output' => array(
+        'param' => 'format',
+        'support' => array(
+          'json',
+        ),
+        'help' => pht(
+          "With '%s', show owners in machine-readable JSON format.",
+          'json'),
+      ),
       '*' => 'paths',
     );
   }
@@ -89,6 +98,18 @@ EOTEXT
     }
     ksort($bypath);
 
+    if ($this->getArgument('output') == 'json') {
+      $this->outputJson($bypath);
+    } else {
+      $this->outputText($bypath);
+    }
+  }
+
+  protected function outputJson($bypath) {
+    echo json_encode($bypath)."\n";
+  }
+
+  protected function outputText($bypath) {
     // The paths are initially sorted alphabetically, but we display them
     // grouped based on their common package. For example, if we have paths
     // "A", "B', "C", and both "A" and "C" are owned by the same packages, the


### PR DESCRIPTION
This commit adds a new `--output=json` option that provides a machine-readable result, organized by file path.